### PR TITLE
linux-tegra: Add logging for sporadic failure after fixdep

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-Logging-fixdep.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-Logging-fixdep.patch
@@ -1,0 +1,54 @@
+From 7d93ea6172d017daa30efe724909fc3adf4cb6c0 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 1 Nov 2019 11:19:40 +0100
+Subject: [PATCH] Test 1
+
+---
+ scripts/Makefile.build | 24 ++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/scripts/Makefile.build b/scripts/Makefile.build
+index 14dc6e89fd18..59dd91047b2d 100644
+--- a/scripts/Makefile.build
++++ b/scripts/Makefile.build
+@@ -252,17 +252,33 @@ define rule_cc_o_c
+ 	$(cmd_modversions_c)						  \
+ 	$(call echo-cmd,record_mcount)					  \
+ 	$(cmd_record_mcount)						  \
+-	scripts/basic/fixdep $(depfile) $@ '$(call make-cmd,cc_o_c)' >    \
+-	                                              $(dot-target).tmp;  \
++	echo '>>> Before fixdep ${dot-target}.tmp' &&                     \
++	scripts/basic/fixdep $(depfile) $@ '$(call make-cmd,cc_o_c)' > $(dot-target).tmp;  \
++	echo ">> fixdep c: ${dot-target} - $?";                           \
+ 	rm -f $(depfile);						  \
++	if [ ! -f ${dot-target}.tmp ]; then                               \
++	    echo ">>> missing dot-target c ${dot-target}.tmp";            \
++	    sleep 5;                                                      \
++	    if [ ! -f ${dot-target}.tmp ]; then                           \
++	         echo ">>> Still missing dot-target c ${dot-target}.tmp"; \
++	    fi;                                                           \
++        fi;                                                              \
+ 	mv -f $(dot-target).tmp $(dot-target).cmd
+ endef
+ 
+ define rule_as_o_S
+        $(call echo-cmd,as_o_S) $(cmd_as_o_S);                            \
+-       scripts/basic/fixdep $(depfile) $@ '$(call make-cmd,as_o_S)' >    \
+-                                                     $(dot-target).tmp;  \
++       echo '>>> Before fixdep as_o_S' &&                                \
++       scripts/basic/fixdep $(depfile) $@ '$(call make-cmd,as_o_S)' > $(dot-target).tmp;  \
++       echo ">> fixdep s: ${dot-target} - $? ";                          \
+        $(cmd_modversions_S)						 \
++       if [ ! -f ${dot-target}.tmp ]; then                               \
++           echo ">>> missing dot target s ${dot-target}.tmp";            \
++           sleep 5;                                                      \
++           if [ ! -f ${dot-target}.tmp ]; then                           \
++                echo ">>> Still missing do-target s ${dot-target}.tmp";  \
++           fi;                                                           \
++       fi;                                                               \
+        rm -f $(depfile);                                                 \
+        mv -f $(dot-target).tmp $(dot-target).cmd
+ endef
+-- 
+2.17.1
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_4.4.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_4.4.bbappend
@@ -10,6 +10,7 @@ SRC_URI_append = " \
 	file://realsense_format_desc_4.4.patch \
 	file://0001-Backport-qmi_wwan-from-kernel-4.14-to-4.4.patch \
 	file://0003-m_ttcan.c-Rename-to-m_ttcan_ext.c.patch \
+        file://0001-Logging-fixdep.patch \
 	"
 
 RESIN_CONFIGS_append = " uvc"


### PR DESCRIPTION
TEST PR, DO NOT MERGE

Happened only once so far, in jenkins, for a file generated by
fixdep to not be found, more specifically
.m_ttcan_ext.o.tmp
```

|   CC [M]  drivers/../nvidia/t18x/drivers/net/can/mttcan/native/../hal/m_ttcan_list.o
|   CC [M]  drivers/../nvidia/t18x/drivers/net/can/mttcan/native/../hal/m_ttcan_ram.o
| mv: cannot stat 'drivers/../nvidia/t18x/drivers/net/can/mttcan/ivc/../hal/.m_ttcan_ext.o.tmp': No such file or directory
| /yocto/resin-board/build/tmp/work-shared/n510-tx2/kernel-source/scripts/Makefile.build:272: recipe for target 'drivers/../nvidia/t18x/drivers/net/can/mttcan/ivc/../hal/m_ttcan_ext.o' failed
| make[8]: *** [drivers/../nvidia/t18x/drivers/net/can/mttcan/ivc/../hal/m_ttcan_ext.o] Error 1
| make[8]: *** Deleting file 'drivers/../nvidia/t18x/drivers/net/can/mttcan/ivc/../hal/m_ttcan_ext.o'
| make[8]: *** Waiting for unfinished jobs....
```

Add some logging and try to reproduce this sporadic issue.