### PR TITLE
resin-image-initramfs: Install tegra-xusb firmware

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/resin-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,1 +1,2 @@
 IMAGE_ROOTFS_MAXSIZE = "12300"
+PACKAGE_INSTALL_append = " tegra-firmware-xusb"


### PR DESCRIPTION
Issuing lsusb will trigger loading of the tegra
xusb firmware, and the first call will fail. This because
when the driver was loaded it failed to load it from the
initramfs as it wasn't present, and after a couple
retries the process was aborted.

Install firmware in initramfs so that it can
be loaded when the driver loads and avoid
usb related issues.

Changelog-entry: resin-image-initramfs: Install tegra-xusb firmware
Signed-off-by: Alexandru Costache <alexandru@balena.io>