### PR TITLE
Fix rollback altboot failed modules loading

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra186-flash-dry_28.3.0.bb
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra186-flash-dry_28.3.0.bb
@@ -168,6 +168,12 @@ do_install() {
 
     cp ${WORKDIR}/partition_specification.txt ${D}/${BINARY_INSTALL_PATH}
     cp ${B}/out/${boot0} ${D}/${BINARY_INSTALL_PATH}
+
+    # extlinux will now be installed in the rootfs,
+    # near the kernel, initrd is not used
+    install -d ${D}/boot/extlinux
+    install -m 0644 ${DEPLOY_DIR_IMAGE}/extlinux.conf ${D}/boot/extlinux/extlinux.conf
+    sed -i 's/Image/boot\/Image/g' ${D}/boot/extlinux/extlinux.conf
 }
 
 do_deploy() {
@@ -176,7 +182,10 @@ do_deploy() {
     cp -r ${D}/${BINARY_INSTALL_PATH}/* ${DEPLOYDIR}/$(basename ${BINARY_INSTALL_PATH})
 }
 
-FILES_${PN} += "${BINARY_INSTALL_PATH}"
+FILES_${PN} += " \
+    ${BINARY_INSTALL_PATH} \
+    /boot/extlinux/ \
+"
 
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"

--- a/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra/0001-load-extlinux-from-active-rootfs.patch
+++ b/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra/0001-load-extlinux-from-active-rootfs.patch
@@ -1,0 +1,49 @@
+From 7eb6f5b1c8fe0d9bc9c414f8090824fe3b74bd93 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 3 Jan 2020 17:00:12 +0100
+Subject: [PATCH] Load extlinux from rootfs for emmc
+
+If board is booted from emmc - mmcblk0 - extlinux.conf
+and Image will be loaded from the current active
+root partition, in case it exists there. In the case
+of a rollback altboot to a previous rootfs version which
+doesn't have extlinux in the rootfs, it will fall back to
+loading the kernel from the boot partiton to avoid complete
+failure.
+
+Otherwise, if booted from sd-card, they will be loaded
+as usual, from the bootable partition flash-boot.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ include/config_distro_bootcmd.h | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
+index 078a2db..91436fb 100644
+--- a/include/config_distro_bootcmd.h
++++ b/include/config_distro_bootcmd.h
+@@ -379,7 +379,18 @@
+ 		"\0"                                                      \
+ 	\
+ 	"scan_dev_for_boot_part="                                         \
+-		"part list ${devtype} ${devnum} -bootable devplist; "     \
++		"if test \"0\" =  \"${devnum}\"; "                        \
++		"then "                                                   \
++		"   if test -e ${devtype} ${devnum}:${resin_root_part} boot/extlinux/extlinux.conf; then " \
++		"       echo Found extlinux.conf on root part: ${resin_root_part}; " \
++		"       setenv devplist ${resin_root_part}; "             \
++		"   else "                                                \
++		"       echo Could not find extlinux.conf on root part, using boot part: ${resin_boot_part}; " \
++		"       setenv devplist ${resin_boot_part}; "             \
++		"   fi; "						  \
++		"else "                                                   \
++		"   part list ${devtype} ${devnum} -bootable devplist; "  \
++		"fi; "                                                    \
+ 		"env exists devplist || setenv devplist $defaultdevplist; " \
+ 		"for distro_bootpart in ${devplist}; do "                 \
+ 			"if fstype ${devtype} "                           \
+-- 
+2.7.4
+

--- a/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -11,4 +11,5 @@ SRC_URI_append = " \
   file://0004-u-boot-Increase-env-size.patch \
   file://0001-menu-Use-default-menu-entry-from-extlinux.conf.patch \
   file://tx2-Integrate-with-Balena-u-boot-environment.patch \
+  file://0001-load-extlinux-from-active-rootfs.patch \
 "

--- a/layers/meta-balena-jetson/recipes-core/images/resin-image-flasher.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image-flasher.bbappend
@@ -1,3 +1,11 @@
 include resin-image.inc
 
 RESIN_BOOT_PARTITION_FILES_append = " extlinux.conf_flasher:/extlinux/extlinux.conf"
+
+# Switch extlinux.conf to the flasher one
+add_extlinux_to_flasher_rootfs() {
+    cp ${DEPLOY_DIR_IMAGE}/extlinux.conf_flasher ${WORKDIR}/rootfs/boot/extlinux/extlinux.conf
+    sed -i 's/Image/boot\/Image/g' ${WORKDIR}/rootfs/boot/extlinux/extlinux.conf
+}
+
+IMAGE_PREPROCESS_COMMAND += " add_extlinux_to_flasher_rootfs; "


### PR DESCRIPTION
Currently rollback-altboot test fails every time a kernel update is performed because, after the kernel panics, there's no hook to update the kernel in the boot partition so it can match the version of the old modules from the old rootfs.

Let's switch to loading the kernel from the root partition, where it exists anyway in the /boot folder.
