### PR TITLE
resin-image-initramfs: Remove unnecessary IMAGE_ROOTFS_MAXSIZE override

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/resin-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,2 +1,1 @@
-IMAGE_ROOTFS_MAXSIZE = "12300"
 PACKAGE_INSTALL_append = " tegra-firmware-xusb"


### PR DESCRIPTION
This is unnecessary since 2.47+

See https://github.com/balena-os/meta-balena/pull/1813 for more detail

Changelog-entry: Remove unnecessary override of IMAGE_ROOTFS_MAXSIZE
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>