### PR TITLE
skx2.coffee: Set private to false for the public device types

### DIFF
--- a/skx2.coffee
+++ b/skx2.coffee
@@ -16,6 +16,7 @@ module.exports =
 	name: 'SKX2'
 	arch: 'aarch64'
 	state: 'released'
+	private: false
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Changelog-entry: Set private to false in .coffee files for the public device types

Signed-off-by: Florin Sarbu <florin@balena.io>