### PR TITLE
modemmanager: Don't include u-blox mode switch script for now

### DIFF
--- a/layers/meta-balena-jetson/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -1,0 +1,26 @@
+# The SKX2 has a TOBY-L210 modem, and recently
+# the u-blox modeswitch scripts were moved from
+# meta-raspberrypi to meta-balena. However,
+# the u-blox-switch.sh script triggers a
+# reboot in the case of succesfull mode switch,
+# which could impact HUP if it hppened right after
+# booting the new OS. Also, it is reported that
+# the modeswitch script is not very stable and fails
+# frequently, so it's better if we did not include
+# this change for the SKX until this gets fixed.
+# See: https://github.com/balena-os/meta-balena/issues/2039
+# and https://github.com/balena-os/balena-raspberrypi/pull/510
+
+SRC_URI_remove = " \
+    file://77-mm-u-blox-modeswitch.rules \
+    file://u-blox-switch@.service \
+    file://u-blox-switch.sh \
+"
+
+do_install_remove = "install -m 0644 ${WORKDIR}/77-mm-u-blox-modeswitch.rules ${D}${base_libdir}/udev/rules.d"
+do_install_remove = "install -m 0755 ${WORKDIR}/u-blox-switch.sh ${D}${bindir}"
+do_install_remove = "install -m 0644 ${WORKDIR}/u-blox-switch@.service ${D}${systemd_unitdir}/system"
+
+FILES_${PN}_remove = "${base_libdir}/udev/rules.d/77-mm-u-blox-modeswitch.rules"
+FILES_${PN}_remove = "${systemd_unitdir}/system/u-blox-switch@.service"
+FILES_${PN}_remove = "${bindir}/u-blox-switch.sh"


### PR DESCRIPTION
modemmanager: Don't include u-blox mode switch script for now
    
    The u-blox mode switch fails frequently, and is
    a known issue, addressed in meta-balena ticket 2039.
    The script can also potentially trigger a reboot right
    after the board boots in the new OS. Let's not include this
    script until a proper fix is in place, because the SKX2
    board uses this type of modem.